### PR TITLE
fix(helm): Explicity define namespace for all resources

### DIFF
--- a/deploy/cert-manager-webhook-duckdns/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-duckdns/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "cert-manager-webhook-duckdns.name" . }}
     chart: {{ include "cert-manager-webhook-duckdns.chart" . }}

--- a/deploy/cert-manager-webhook-duckdns/templates/secret.yaml
+++ b/deploy/cert-manager-webhook-duckdns/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.secretName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "cert-manager-webhook-duckdns.name" . }}
     chart: {{ include "cert-manager-webhook-duckdns.chart" . }}

--- a/deploy/cert-manager-webhook-duckdns/templates/service.yaml
+++ b/deploy/cert-manager-webhook-duckdns/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "cert-manager-webhook-duckdns.name" . }}
     chart: {{ include "cert-manager-webhook-duckdns.chart" . }}


### PR DESCRIPTION
helm install sets missing namespaces to the given --namespace argument, but helm template does not.
This means alternate workflows that do not use helm install directly (such as kustomize's
helmChartInflationGenerator) deploy those resources to the default namespace.