### PR TITLE
Draft: using cert-manager.io/v1 as apiVersion for certmanager 1.6.0 Support

### DIFF
--- a/deploy/cert-manager-webhook-duckdns/Chart.yaml
+++ b/deploy/cert-manager-webhook-duckdns/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: cert-manager-webhook-duckdns
-version: v1.2.2
+version: v1.3.0
 appVersion: v1.2.2
 description: A Helm chart for cert manager webhook solver for ACME DNS01 challenge via DuckDNS
 home: https://github.com/ebrianne/cert-manager-webhook-duckdns

--- a/deploy/cert-manager-webhook-duckdns/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-duckdns/templates/pki.yaml
@@ -1,7 +1,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.selfSignedIssuer" . }}
@@ -17,7 +17,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.rootCACertificate" . }}
@@ -38,7 +38,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.rootCAIssuer" . }}
@@ -55,7 +55,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "cert-manager-webhook-duckdns.servingCertificate" . }}


### PR DESCRIPTION
Hi, 

thanks for the nice development! Currently i have the Problem that the CertManager `>=1.6.0` not more works with `cert-manager.io/v1alpha2`, [Changelog cert-manager v1.6.0](https://github.com/jetstack/cert-manager/releases/tag/v1.6.0). 

Here some small fix for the last used places.
