### PR TITLE
fix to get latest domain name to challenge

### DIFF
--- a/duckdns/solver.go
+++ b/duckdns/solver.go
@@ -88,9 +88,9 @@ func (s *duckDNSProviderSolver) getDNSName(ch *v1alpha1.ChallengeRequest) []stri
 	duckdnszone = util.UnFqdn(duckdnszone)                             //<suffix>.<domain> or <domain>
 	split := strings.Split(duckdnszone, ".")
 
-	if len(split) == 2 {
-		klog.Infof("Got dns domain from challenge %v", split[1])
-		out = append(out, split[1])
+	if len(split) > 1 {
+		klog.Infof("Got dns domain from challenge %v", split[len(split)-1])
+		out = append(out, split[len(split)-1])
 		return out
 	}
 


### PR DESCRIPTION
ex) `a.b.c.your.duckdns.org` -> always challenge with `your`, not `a.b.c.your`.

fixes #14 