### PR TITLE
Feature/update to alpine 1.21 go 1.24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore sensitive environment files
+testdata/duckdns/env.testconfig
+testdata/duckdns/api-key.yml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ __main__/
 
 # Test binary, build
 _out/
+
+# Test config for Unit Test
+testdata/duckdns/env.testconfig
+testdata/duckdns/api-key.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.15-alpine3.12 AS build_deps
+ARG GO_VERSION=1.24
+ARG ALPINE_VERSION=3.21
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build_deps
 
 RUN apk add --no-cache git
 
@@ -17,7 +20,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
 
-FROM alpine:latest
+FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfile.unittest
+++ b/Dockerfile.unittest
@@ -1,0 +1,44 @@
+ARG GO_VERSION=1.24
+ARG ALPINE_VERSION=3.21
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build_deps
+
+RUN apk add --no-cache git bash curl tar
+
+WORKDIR /workspace
+ENV GO111MODULE=on
+ENV GOPATH="/workspace/.go"
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+FROM build_deps AS build
+
+COPY . .
+
+# Download dependencies
+RUN go mod download
+
+# Set up test data
+RUN cp testdata/duckdns/api-key.yml.sample testdata/duckdns/api-key.yml
+RUN rm testdata/duckdns/api-key.yml.sample
+
+COPY scripts/fetch-test-binaries.sh scripts/fetch-test-binaries.sh 
+# Make the fetch-test-binaries script executable
+RUN chmod +x scripts/fetch-test-binaries.sh
+
+# Fetch test binaries; On alpine we use apk to install our required binaries
+RUN ./scripts/fetch-test-binaries.sh
+
+# Enable debug logging
+ENV ACME_CERT_MANAGER_WEBHOOK_DUCKDNS_DEBUG=true
+
+# Updated CMD to correctly replace the token
+CMD bash -c '\
+    if [ -n "$DUCKDNS_TOKEN" ]; then \
+        echo "Replacing DuckDNS token in api-key.yml"; \
+        sed -i "s|duckdns-token: <BASE64 API KEY>|duckdns-token: $(echo -n "$DUCKDNS_TOKEN" | base64)|g" testdata/duckdns/api-key.yml; \
+    fi && \
+    TEST_ZONE_NAME=$TEST_ZONE_NAME DNS_NAME=$DNS_NAME go test -v'
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-IMAGE_NAME := "ebrianne/cert-manager-webhook-duckdns"
+IMAGE_NAME ?= "ebrianne/cert-manager-webhook-duckdns"
 IMAGE_TAG := "latest"
+PLATFORMS := "linux/amd64,linux/arm64"
+BUILDKIT_COMPRESSION := "zstd"
+BUILDKIT_COMPRESSION_LEVEL := "9"
 
 OUT := $(shell pwd)/_out
 
@@ -8,6 +11,13 @@ $(shell mkdir -p "$(OUT)")
 verify:
 	go test -v .
 
+buildx:
+	docker buildx build --platform $(PLATFORMS) --tag $(IMAGE_NAME):$(IMAGE_TAG) --provenance=mode=max . 
+
+release: buildx
+	docker buildx build --platform $(PLATFORMS) --tag $(IMAGE_NAME):$(IMAGE_TAG) --provenance=mode=max . --push
+
+#don't change existing build commands
 build:
 	docker build -t "$(IMAGE_NAME):$(IMAGE_TAG)" .
 
@@ -18,3 +28,22 @@ rendered-manifest.yaml:
         --set image.repository=$(IMAGE_NAME) \
         --set image.tag=$(IMAGE_TAG) \
         deploy/cert-manager-webhook-duckdns > "$(OUT)/rendered-manifest.yaml"
+
+test:
+	TEST_ZONE_NAME="duckdns.org." DNS_NAME="test.duckdns.org" go test -v .
+
+# Check for required environment variables in .env file
+.PHONY: check-env-file
+check-env-file:
+	@if [ ! -f testdata/duckdns/env.testconfig ]; then \
+		echo "Error: testdata/duckdns/env.testconfigfile not found"; \
+		exit 1; \
+	fi
+
+docker-build-unittest:
+	docker build -f Dockerfile.unittest -t cert-manager-webhook-duckdns:test .
+
+docker-run-unittest:
+	source testdata/duckdns/env.testconfig && docker run --rm -e TEST_ZONE_NAME=$${TEST_ZONE_NAME} -e DNS_NAME=$${DNS_NAME} -e DUCKDNS_TOKEN=$${DUCKDNS_TOKEN} cert-manager-webhook-duckdns:test
+
+docker-unittest: check-env-file docker-build-unittest docker-run-unittest

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,117 @@
+# Testing the DuckDNS Webhook for cert-manager
+
+This document describes how to test the DuckDNS webhook for cert-manager.
+
+## Prerequisites
+
+- Docker
+- A DuckDNS account and API token
+- A DuckDNS domain for testing
+
+## Setting Up Test Configuration
+
+1. Copy the example test configuration:
+
+```bash
+cp testdata/duckdns/env.testconfig.example testdata/duckdns/env.testconfig
+```
+
+2. Edit the configuration file to include your DuckDNS token and domain:
+
+```bash
+# testdata/duckdns/env.testconfig
+export DUCKDNS_TOKEN=<your DuckDNS token>
+export TEST_ZONE_NAME=<your-domain>.duckdns.org.  # Note the trailing dot
+export DNS_NAME=<your-domain>.duckdns.org  # No trailing dot
+```
+
+3. Build and run Docker unit test, it has items we don't use for production, and only run the test and quits.
+
+```
+make docker-unittest
+```
+
+The unit test uses the go modules from : https://pkg.go.dev/github.com/ebrianne/duckdns-go#section-readme
+
+They mock a kube-api call using etcd.
+They expect binaries in hardcoded locations. 
+
+The line that indicates success is this one, it indicates it successfully created a challenge entry:
+
+```
+# Key line to look for:
+**I0318 21:15:21.313985   12025 solver.go:168] Got txt record: 123d==**
+
+
+Example output of running unit test via Docker
+
+Replacing DuckDNS token in api-key.yml
+
+=== RUN   TestRunsSuite
+    fixture.go:127: started apiserver on "http://127.0.0.1:36203"
+
+=== RUN   TestRunsSuite/Conformance
+=== RUN   TestRunsSuite/Conformance/Basic
+=== RUN   TestRunsSuite/Conformance/Basic/PresentRecord
+
+    util.go:68: created fixture "basic-present-record"
+    suite.go:37: Calling Present with ChallengeRequest: &v1alpha1.ChallengeRequest{
+        UID: "",
+        Action: "",
+        Type: "",
+        DNSName: "<REDACTED>.duckdns.org",
+        Key: "123d==",
+        ResourceNamespace: "basic-present-record",
+        ResolvedFQDN: "cert-manager-dns01-tests.<REDACTED>.duckdns.org.",
+        ResolvedZone: "<REDACTED>.duckdns.org.",
+        AllowAmbientCredentials: false,
+        Config: (*v1beta1.JSON)(0x400048a3f0),
+    }
+
+I0318 21:13:46.721003   12025 solver.go:127] Presenting txt record: cert-manager-dns01-tests.<REDACTED>.duckdns.org. <REDACTED>.duckdns.org.
+I0318 21:13:46.721069   12025 solver.go:66] Decoded config: {{{duckdns-token} duckdns-token}}
+I0318 21:13:46.729000   12025 solver.go:85] DNSName from ChallengeRequest is <REDACTED>.duckdns.org
+I0318 21:13:46.729105   12025 solver.go:97] Got dns domain from challenge <REDACTED>
+I0318 21:13:46.729113   12025 solver.go:135] Present txt record for domain <REDACTED>
+I0318 21:13:46.729117   12025 client.go:105] Sending request to https://www.duckdns.org/update?domains=<REDACTED>&token=*********&txt=123d==
+I0318 21:13:47.092179   12025 solver.go:142] Presented txt record cert-manager-dns01-tests.<REDACTED>.duckdns.org.
+
+[... DNS lookup and timeout messages omitted ...]
+
+I0318 21:15:20.361755   12025 solver.go:85] DNSName from ChallengeRequest is <REDACTED>.duckdns.org
+I0318 21:15:20.361771   12025 solver.go:97] Got dns domain from challenge <REDACTED>
+I0318 21:15:20.361787   12025 solver.go:161] Cleaning up txt record for domain <REDACTED>
+
+# Key line to look for:
+**I0318 21:15:21.313985   12025 solver.go:168] Got txt record: 123d==**
+
+I0318 21:15:21.314040   12025 client.go:105] Sending request to https://www.duckdns.org/update?domains=<REDACTED>&token=*********&txt=123d==&clear=true
+I0318 21:15:21.588405   12025 solver.go:180] Cleaned up txt record: cert-manager-dns01-tests.<REDACTED>.duckdns.org. <REDACTED>.duckdns.org.
+
+[... more cleanup messages omitted ...]
+
+=== RUN   TestRunsSuite/Conformance/Extended
+=== RUN   TestRunsSuite/Conformance/Extended/DeletingOneRecordRetainsOthers
+
+    suite.go:73: skipping test as strict mode is disabled, see: https://github.com/jetstack/cert-manager/pull/1354
+
+--- PASS: TestRunsSuite (121.47s)
+    --- PASS: TestRunsSuite/Conformance (99.79s)
+        --- PASS: TestRunsSuite/Conformance/Basic (99.79s)
+            --- PASS: TestRunsSuite/Conformance/Basic/PresentRecord (99.79s)
+        --- PASS: TestRunsSuite/Conformance/Extended (0.00s)
+            --- SKIP: TestRunsSuite/Conformance/Extended/DeletingOneRecordRetainsOthers (0.00s)
+
+PASS
+ok  	github.com/ebrianne/cert-manager-webhook-duckdns	121.498s
+
+
+##Additional Notes
+You cannot test on macos as it depends on linux specific network code, you will get this eror on macos:
+```
+go test -v .
+# github.com/ebrianne/cert-manager-webhook-duckdns.test
+link: golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg
+FAIL	github.com/ebrianne/cert-manager-webhook-duckdns [build failed]
+FAIL
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ebrianne/cert-manager-webhook-duckdns
 
-go 1.15
+go 1.24
 
 require (
 	github.com/ebrianne/duckdns-go v1.0.3
@@ -10,4 +10,78 @@ require (
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v0.19.0
 	k8s.io/klog/v2 v2.8.0
+)
+
+require (
+	github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.0+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.3 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/go-cmp v0.4.1 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/miekg/dns v1.1.31 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/gomega v1.10.1 // indirect
+	github.com/prometheus/client_golang v1.7.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.10.0 // indirect
+	github.com/prometheus/procfs v0.1.3 // indirect
+	github.com/spf13/cobra v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5 // indirect
+	go.uber.org/atomic v1.4.0 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
+	go.uber.org/zap v1.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	google.golang.org/grpc v1.27.0 // indirect
+	google.golang.org/protobuf v1.24.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	k8s.io/api v0.19.0 // indirect
+	k8s.io/apiserver v0.19.0 // indirect
+	k8s.io/component-base v0.19.0 // indirect
+	k8s.io/kube-aggregator v0.19.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6 // indirect
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.0.1 // indirect
+	sigs.k8s.io/testing_frameworks v0.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -74,7 +74,6 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -861,7 +860,6 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/scripts/fetch-test-binaries.sh
+++ b/scripts/fetch-test-binaries.sh
@@ -1,3 +1,76 @@
 #!/usr/bin/env bash
-mkdir -p __main__/hack
-curl -sfL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_darwin_amd64.tar.gz | tar xvz --strip-components=1 -C __main__/hack
+set -e
+
+#later versions are executables and not just tar.gz files so less useful
+#this particular kubebulder version has these versions of  etcd=3.3.11, and kubectl/kube-apiserver v1.16.4
+KUBEBUILDER_VERSION="v2.3.2"
+
+echo "Setting up test binaries..."
+# Determine OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+# Early check for MacOS ARM64 (M1/M2)
+if [ "$OS" = "darwin" ] && [ "$ARCH" = "arm64" ]; then
+    echo "ERROR: This script cannot run directly on MacOS ARM64 (Apple Silicon)."
+    echo "Please use Docker to run the tests, which will provide the correct Linux environment."
+    echo "no point to grab the test binaries on architectures we cannot test on."
+    echo "go relies on network code that requires linux"
+    echo "the version 2.3.2 does not support darwin/arm64, so we nope out on that one"
+    exit 1
+fi
+
+# Determine the target architecture for binaries
+case $ARCH in
+    x86_64)
+        KUBE_ARCH="amd64"
+        ;;
+    aarch64)
+        KUBE_ARCH="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH, falling back to amd64"
+        KUBE_ARCH="amd64"
+        ;;
+esac
+
+echo "Detected: OS=$OS, ARCH=$ARCH (using KUBE_ARCH=$KUBE_ARCH)"
+
+# Ensure we're targeting linux for the binaries regardless of host OS
+if [ "$OS" != "linux" ]; then
+    echo "Note: Running on $OS but downloading Linux binaries for use in Docker/containers"
+    TARGET_OS="linux"
+else
+    TARGET_OS="linux"
+fi
+
+mkdir -p __main__/hack/bin
+
+# Try architecture-specific version first, then fall back to amd64 if needed
+
+ARCH_URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION#v}_${TARGET_OS}_${KUBE_ARCH}.tar.gz"
+
+# Check if architecture-specific version exists
+if curl --output /dev/null --silent --head --fail "$ARCH_URL"; then
+    echo "Found $KUBE_ARCH version of kubebuilder. Downloading from $ARCH_URL"
+    curl -sfL "$ARCH_URL" | tar xvz --strip-components=1 -C __main__/hack
+else
+    echo "No $KUBE_ARCH version available. Falling back to amd64 version..."
+    AMD64_URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION#v}_${TARGET_OS}_amd64.tar.gz"
+    echo "Downloading from $AMD64_URL"
+    curl -sfL "$AMD64_URL" | tar xvz --strip-components=1 -C __main__/hack
+fi
+
+# Ensure binaries are in the expected location and have correct permissions
+for binary in etcd kube-apiserver kubectl; do
+    if [ -f "__main__/hack/$binary" ]; then
+        echo "Installing $binary to __main__/hack/bin/"
+        cp "__main__/hack/$binary" "__main__/hack/bin/" || ln -sf "../$binary" "__main__/hack/bin/$binary"
+        chmod +x "__main__/hack/bin/$binary"
+    else
+        echo "Warning: $binary not found in extracted files"
+    fi
+done
+
+echo "Test binaries ready:"
+ls -la __main__/hack/bin/

--- a/testdata/duckdns/env.testconfig.example
+++ b/testdata/duckdns/env.testconfig.example
@@ -1,0 +1,3 @@
+export DUCKDNS_TOKEN=<THIS is your DUCKDNS token>
+export TEST_ZONE_NAME=SOMESUPERCOOLDOMAIN.duckdns.org.
+export DNS_NAME=SOMESUPERCOOLDOMAIN.duckdns.org


### PR DESCRIPTION
Upgrade to Alpine 1.21
Upgrade to go 1.24
Build multi-arch arm64/amd64 images that are compressed with zstd
Add in a new docker image that allows running the unit test in a throwaway docker image.
Update documentation on how to setup, run, and evaluate the unit test : Testing.md